### PR TITLE
Add sequential parallax reveal for hero artwork

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,19 +31,28 @@
   <main>
     <section id="hero" class="hero" aria-label="Starstruck Galaxy hero section">
       <div class="parallax" aria-hidden="true">
-        <div class="layer layer--logo" data-speed="0.25">
+        <div class="layer layer--7" data-speed="0.15" data-reveal="0">
           <div class="layer__image" role="presentation"></div>
         </div>
-        <div class="layer layer--far-bg" data-speed="0.4">
+        <div class="layer layer--6" data-speed="0.25" data-reveal="1">
           <div class="layer__image" role="presentation"></div>
         </div>
-        <div class="layer layer--near-bg" data-speed="0.55">
+        <div class="layer layer--5" data-speed="0.35" data-reveal="2">
           <div class="layer__image" role="presentation"></div>
         </div>
-        <div class="layer layer--far-fg" data-speed="0.7">
+        <div class="layer layer--4" data-speed="0.45" data-reveal="3">
           <div class="layer__image" role="presentation"></div>
         </div>
-        <div class="layer layer--near-fg" data-speed="0.9">
+        <div class="layer layer--3" data-speed="0.6" data-reveal="4">
+          <div class="layer__image" role="presentation"></div>
+        </div>
+        <div class="layer layer--2" data-speed="0.75" data-reveal="5">
+          <div class="layer__image" role="presentation"></div>
+        </div>
+        <div class="layer layer--1" data-speed="0.9" data-reveal="6">
+          <div class="layer__image" role="presentation"></div>
+        </div>
+        <div class="layer layer--0" data-speed="1.05" data-reveal="7">
           <div class="layer__image" role="presentation"></div>
         </div>
       </div>

--- a/scripts.js
+++ b/scripts.js
@@ -11,6 +11,17 @@
     return;
   }
 
+  const layerData = Array.from(layers).map((layer) => ({
+    element: layer,
+    speed: Number(layer.dataset.speed) || 0,
+    reveal: Number(layer.dataset.reveal || 0),
+  }));
+
+  const maxRevealOrder = layerData.reduce(
+    (max, layer) => (layer.reveal > max ? layer.reveal : max),
+    0
+  );
+
   const heroRect = hero.getBoundingClientRect();
   let heroTop = heroRect.top + window.scrollY;
   let heroHeight = heroRect.height;
@@ -24,11 +35,21 @@
   const handleScroll = () => {
     const scrollY = window.scrollY;
     const progress = Math.min(Math.max((scrollY - heroTop) / heroHeight, 0), 1.5);
+    const revealProgress = Math.min(Math.max((scrollY - heroTop) / heroHeight, 0), 1);
 
-    layers.forEach((layer) => {
-      const speed = Number(layer.dataset.speed) || 0;
+    layerData.forEach(({ element, speed, reveal }) => {
       const translate = progress * speed * -120;
-      layer.style.transform = `translate3d(0, ${translate}vh, 0)`;
+      element.style.transform = `translate3d(0, ${translate}vh, 0)`;
+
+      if (reveal === 0 || maxRevealOrder === 0) {
+        element.style.opacity = '1';
+        return;
+      }
+
+      const step = 1 / maxRevealOrder;
+      const start = (reveal - 1) * step;
+      const opacity = Math.min(Math.max((revealProgress - start) / step, 0), 1);
+      element.style.opacity = opacity.toString();
     });
   };
 

--- a/styles.css
+++ b/styles.css
@@ -132,45 +132,87 @@ a:focus-visible {
 
 .layer {
   position: absolute;
-  inset: -10vh -10vw;
-  display: grid;
-  place-items: center;
+  inset: -12vh -12vw;
   transform: translateZ(0);
+  opacity: 0;
+  transition: opacity 0.6s ease-out;
+}
+
+.layer[data-reveal='0'] {
+  opacity: 1;
 }
 
 .layer__image {
-  width: min(900px, 85vw);
-  aspect-ratio: 1;
-  border-radius: 24px;
-  background: linear-gradient(135deg, rgba(61, 231, 255, 0.28), rgba(255, 79, 216, 0.36));
-  box-shadow: var(--shadow-elevated);
-  backdrop-filter: blur(6px);
-  border: 1px solid rgba(247, 244, 255, 0.2);
+  width: 100%;
+  height: 100%;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: contain;
 }
 
-.layer--logo .layer__image {
-  background: url('assets/hero-logo.png') center/contain no-repeat,
-    linear-gradient(135deg, rgba(255, 79, 216, 0.5), rgba(61, 231, 255, 0.5));
+.layer--7 {
+  z-index: 1;
 }
 
-.layer--far-bg .layer__image {
-  background: url('assets/hero-far-background.png') center/cover no-repeat,
-    linear-gradient(160deg, rgba(13, 2, 33, 0.9), rgba(61, 231, 255, 0.25));
+.layer--6 {
+  z-index: 2;
 }
 
-.layer--near-bg .layer__image {
-  background: url('assets/hero-near-background.png') center/contain no-repeat,
-    linear-gradient(200deg, rgba(61, 231, 255, 0.4), rgba(255, 79, 216, 0.45));
+.layer--5 {
+  z-index: 3;
 }
 
-.layer--far-fg .layer__image {
-  background: url('assets/hero-far-foreground.png') center/contain no-repeat,
-    linear-gradient(215deg, rgba(61, 231, 255, 0.3), rgba(255, 216, 79, 0.35));
+.layer--4 {
+  z-index: 4;
 }
 
-.layer--near-fg .layer__image {
-  background: url('assets/hero-near-foreground.png') center/contain no-repeat,
-    linear-gradient(215deg, rgba(255, 79, 216, 0.4), rgba(255, 216, 79, 0.35));
+.layer--3 {
+  z-index: 5;
+}
+
+.layer--2 {
+  z-index: 6;
+}
+
+.layer--1 {
+  z-index: 7;
+}
+
+.layer--0 {
+  z-index: 8;
+}
+
+.layer--7 .layer__image {
+  background-image: url('hero_7.png');
+  background-size: cover;
+}
+
+.layer--6 .layer__image {
+  background-image: url('hero_6.png');
+}
+
+.layer--5 .layer__image {
+  background-image: url('hero_5.png');
+}
+
+.layer--4 .layer__image {
+  background-image: url('hero_4.png');
+}
+
+.layer--3 .layer__image {
+  background-image: url('hero_3.png');
+}
+
+.layer--2 .layer__image {
+  background-image: url('hero_2.png');
+}
+
+.layer--1 .layer__image {
+  background-image: url('hero_1.png');
+}
+
+.layer--0 .layer__image {
+  background-image: url('hero_0.png');
 }
 
 .hero__content {


### PR DESCRIPTION
## Summary
- replace the hero section parallax markup with eight layers mapped to hero_0 through hero_7 images
- update parallax styling for the new artwork stack and ensure the far background remains visible initially
- reveal each additional layer progressively as the user scrolls while maintaining parallax movement

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d6d3ee489c832f8eed67a8d8223e31