### PR TITLE
Pin hero parallax stage until layers reveal

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,36 +30,38 @@
 
   <main>
     <section id="hero" class="hero" aria-label="Starstruck Galaxy hero section">
-      <div class="parallax" aria-hidden="true">
-        <div class="layer layer--7" data-speed="0.15" data-reveal="0">
-          <div class="layer__image" role="presentation"></div>
+      <div class="hero__inner">
+        <div class="parallax" aria-hidden="true">
+          <div class="layer layer--7" data-speed="0.15" data-reveal="0">
+            <div class="layer__image" role="presentation"></div>
+          </div>
+          <div class="layer layer--6" data-speed="0.25" data-reveal="1">
+            <div class="layer__image" role="presentation"></div>
+          </div>
+          <div class="layer layer--5" data-speed="0.35" data-reveal="2">
+            <div class="layer__image" role="presentation"></div>
+          </div>
+          <div class="layer layer--4" data-speed="0.45" data-reveal="3">
+            <div class="layer__image" role="presentation"></div>
+          </div>
+          <div class="layer layer--3" data-speed="0.6" data-reveal="4">
+            <div class="layer__image" role="presentation"></div>
+          </div>
+          <div class="layer layer--2" data-speed="0.75" data-reveal="5">
+            <div class="layer__image" role="presentation"></div>
+          </div>
+          <div class="layer layer--1" data-speed="0.9" data-reveal="6">
+            <div class="layer__image" role="presentation"></div>
+          </div>
+          <div class="layer layer--0" data-speed="1.05" data-reveal="7">
+            <div class="layer__image" role="presentation"></div>
+          </div>
         </div>
-        <div class="layer layer--6" data-speed="0.25" data-reveal="1">
-          <div class="layer__image" role="presentation"></div>
+        <div class="hero__content container">
+          <h1 class="hero__title">Blast Off Into a Funky Musical Universe</h1>
+          <p class="hero__subtitle">Compose cosmic beats, remix stellar sounds, and explore the galaxy one groove at a time.</p>
+          <a class="cta-button" href="#newsletter">Join the Crew</a>
         </div>
-        <div class="layer layer--5" data-speed="0.35" data-reveal="2">
-          <div class="layer__image" role="presentation"></div>
-        </div>
-        <div class="layer layer--4" data-speed="0.45" data-reveal="3">
-          <div class="layer__image" role="presentation"></div>
-        </div>
-        <div class="layer layer--3" data-speed="0.6" data-reveal="4">
-          <div class="layer__image" role="presentation"></div>
-        </div>
-        <div class="layer layer--2" data-speed="0.75" data-reveal="5">
-          <div class="layer__image" role="presentation"></div>
-        </div>
-        <div class="layer layer--1" data-speed="0.9" data-reveal="6">
-          <div class="layer__image" role="presentation"></div>
-        </div>
-        <div class="layer layer--0" data-speed="1.05" data-reveal="7">
-          <div class="layer__image" role="presentation"></div>
-        </div>
-      </div>
-      <div class="hero__content container">
-        <h1 class="hero__title">Blast Off Into a Funky Musical Universe</h1>
-        <p class="hero__subtitle">Compose cosmic beats, remix stellar sounds, and explore the galaxy one groove at a time.</p>
-        <a class="cta-button" href="#newsletter">Join the Crew</a>
       </div>
     </section>
 

--- a/scripts.js
+++ b/scripts.js
@@ -1,13 +1,14 @@
 (function () {
   const layers = document.querySelectorAll('.layer');
   const hero = document.getElementById('hero');
+  const heroInner = hero ? hero.querySelector('.hero__inner') : null;
   const yearEl = document.getElementById('year');
 
   if (yearEl) {
     yearEl.textContent = new Date().getFullYear();
   }
 
-  if (!hero || !layers.length) {
+  if (!hero || !layers.length || !heroInner) {
     return;
   }
 
@@ -22,20 +23,27 @@
     0
   );
 
+  const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+
   const heroRect = hero.getBoundingClientRect();
   let heroTop = heroRect.top + window.scrollY;
-  let heroHeight = heroRect.height;
+  let heroHeight = hero.offsetHeight;
+  let heroInnerHeight = heroInner.offsetHeight;
+  let pinDistance = Math.max(heroHeight - heroInnerHeight, 1);
 
   const updateMetrics = () => {
     const rect = hero.getBoundingClientRect();
     heroTop = rect.top + window.scrollY;
-    heroHeight = rect.height;
+    heroHeight = hero.offsetHeight;
+    heroInnerHeight = heroInner.offsetHeight;
+    pinDistance = Math.max(heroHeight - heroInnerHeight, 1);
   };
 
   const handleScroll = () => {
     const scrollY = window.scrollY;
-    const progress = Math.min(Math.max((scrollY - heroTop) / heroHeight, 0), 1.5);
-    const revealProgress = Math.min(Math.max((scrollY - heroTop) / heroHeight, 0), 1);
+    const pinnedScroll = scrollY - heroTop;
+    const progress = clamp(pinnedScroll / pinDistance, 0, 1);
+    const revealProgress = progress;
 
     layerData.forEach(({ element, speed, reveal }) => {
       const translate = progress * speed * -120;

--- a/styles.css
+++ b/styles.css
@@ -16,6 +16,7 @@
   --color-text-muted: rgba(247, 244, 255, 0.7);
   --shadow-elevated: 0 24px 64px rgba(0, 0, 0, 0.45);
   --max-width: 1100px;
+  --hero-pin-distance: 140vh;
   color-scheme: dark;
 }
 
@@ -116,6 +117,12 @@ a:focus-visible {
 
 .hero {
   position: relative;
+  padding-bottom: var(--hero-pin-distance);
+}
+
+.hero__inner {
+  position: sticky;
+  top: 0;
   min-height: clamp(720px, 110vh, 960px);
   display: grid;
   align-items: end;


### PR DESCRIPTION
## Summary
- wrap the hero parallax imagery in a sticky inner container so the frame stays fixed during the reveal
- add CSS tuning for the pinned hero stage to control the scroll distance before releasing the section
- adjust the parallax script to base animation progress on the pinned distance and keep opacity reveals in sync

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d6d8f2de0c832f81302599a831e02d