### PR TITLE
Implement scroll-driven hero image reveal

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -6,7 +6,6 @@
 })();
 
 (function () {
-  // Respect reduced motion
   const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
   if (reduce || typeof gsap === 'undefined') return;
 
@@ -15,49 +14,51 @@
   const stage = document.querySelector('#hero .parallax-stage');
   if (!stage) return;
 
-  // Collect layers foreground -> background (0..7). If some IDs missing, fall back to class order.
-  const layers = [];
-  for (let i = 0; i <= 7; i++) {
-    const el = document.getElementById('hero_' + i);
-    if (el) layers.push(el);
-  }
-  if (!layers.length) {
-    document.querySelectorAll('#hero .parallax-layer').forEach((el) => layers.push(el));
-  }
+  const layers = Array.from(stage.querySelectorAll('.parallax-layer'));
+  if (!layers.length) return;
 
-  // Parallax factors: foreground moves most, background least.
-  const factors = [1.0, 0.85, 0.7, 0.55, 0.4, 0.3, 0.2, 0.12];
+  const anchorLayer = stage.querySelector('#hero_7') || layers[layers.length - 1];
+  const movingLayers = layers.filter((layer) => layer !== anchorLayer).reverse();
 
-  // Start offset in viewport-relative units so it scales on mobile/desktop.
-  const baseOffsetVH = 18; // tweak for more/less travel
+  if (!movingLayers.length) return;
 
-  // Ensure everything starts with the “sun” composition centered;
-  // we only move layers relative to that frame.
-  layers.forEach((el, idx) => {
-    const f = factors[idx] ?? factors[factors.length - 1];
-    gsap.set(el, { yPercent: baseOffsetVH * f });
+  const baseOffset = 120;
+  const offsetStep = 18;
+
+  movingLayers.forEach((layer, index) => {
+    const offset = baseOffset + offsetStep * index;
+    gsap.set(layer, { yPercent: offset });
   });
 
-  // Build timeline mapped to scroll; pin the section.
-  const tl = gsap.timeline({
+  gsap.set(anchorLayer, { yPercent: 0 });
+
+  const slowDuration = 1.1;
+  const fastDuration = 0.35;
+  const count = movingLayers.length;
+  const durationStep = count > 1 ? (slowDuration - fastDuration) / (count - 1) : 0;
+  const baseDelay = slowDuration;
+  const finalDuration = slowDuration - durationStep * (count - 1);
+  const totalDuration = (count - 1) * baseDelay + finalDuration;
+  const scrollSpan = Math.max(totalDuration * 80, 320);
+
+  const timeline = gsap.timeline({
     defaults: { ease: 'none' },
     scrollTrigger: {
-      trigger: '#hero',
+      trigger: stage,
       start: 'top top',
-      end: '+=200%',
+      end: () => `+=${scrollSpan}%`,
       scrub: true,
-      pin: true,
+      pin: stage,
       anticipatePin: 1,
     },
   });
 
-  // Animate each layer upward to y=0. Background (higher index) moves less.
-  layers.forEach((el, idx) => {
-    const f = factors[idx] ?? factors[factors.length - 1];
-    tl.to(el, { yPercent: 0 }, 0);
+  movingLayers.forEach((layer, index) => {
+    const duration = slowDuration - durationStep * index;
+    const startTime = index * baseDelay;
+    timeline.to(layer, { yPercent: 0, duration }, startTime);
   });
 
-  // Refresh on resize/orientation changes
   const refresh = () => ScrollTrigger.refresh();
   window.addEventListener('resize', refresh);
   window.addEventListener('orientationchange', refresh);

--- a/styles.css
+++ b/styles.css
@@ -16,7 +16,6 @@
   --color-text-muted: rgba(247, 244, 255, 0.7);
   --shadow-elevated: 0 24px 64px rgba(0, 0, 0, 0.45);
   --max-width: 1100px;
-  --hero-pin-distance: 140vh;
   color-scheme: dark;
 }
 
@@ -117,105 +116,13 @@ a:focus-visible {
 
 .hero {
   position: relative;
-  padding-bottom: var(--hero-pin-distance);
+  padding: clamp(6rem, 11vw, 8rem) 0 clamp(4rem, 9vw, 6rem);
 }
 
 .hero__inner {
-  position: sticky;
-  top: 0;
-  min-height: clamp(720px, 110vh, 960px);
   display: grid;
-  align-items: end;
-  padding: 12rem 0 6rem;
-  overflow: hidden;
-}
-
-.parallax {
-  position: absolute;
-  inset: 0;
-  overflow: hidden;
-  pointer-events: none;
-}
-
-.layer {
-  position: absolute;
-  inset: -12vh -12vw;
-  transform: translate3d(0, 50vh, 0);
-  opacity: 0;
-  transition: opacity 0.6s ease-out;
-}
-
-.layer__image {
-  width: 100%;
-  height: 100%;
-  background-position: center;
-  background-repeat: no-repeat;
-  background-size: contain;
-}
-
-.layer--7 {
-  z-index: 1;
-}
-
-.layer--6 {
-  z-index: 2;
-}
-
-.layer--5 {
-  z-index: 3;
-}
-
-.layer--4 {
-  z-index: 4;
-}
-
-.layer--3 {
-  z-index: 5;
-}
-
-.layer--2 {
-  z-index: 6;
-}
-
-.layer--1 {
-  z-index: 7;
-}
-
-.layer--0 {
-  z-index: 8;
-}
-
-.layer--7 .layer__image {
-  background-image: url('hero_7.png');
-  background-size: cover;
-}
-
-.layer--6 .layer__image {
-  background-image: url('hero_6.png');
-}
-
-.layer--5 .layer__image {
-  background-image: url('hero_5.png');
-}
-
-.layer--4 .layer__image {
-  background-image: url('hero_4.png');
-}
-
-.layer--3 .layer__image {
-  background-image: url('hero_3.png');
-}
-
-.layer--2 .layer__image {
-  background-image: url('hero_2.png');
-}
-
-.layer--1 .layer__image {
-  background-image: url('hero_1.png');
-}
-
-.layer--0 .layer__image {
-  background-image: url('hero_0.png');
+  gap: clamp(4rem, 8vw, 6rem);
+  justify-items: center;
 }
 
 .hero__content {
@@ -410,9 +317,16 @@ a:focus-visible {
 /* Maintain a square stage that scales responsively. Change aspect via data-aspect if needed */
 .parallax-stage {
   position: relative;
-  width: min(90vmin, 100vw);
+  width: min(90vmin, 960px);
   aspect-ratio: 1 / 1;
   max-height: 90vh;
+  margin: 0 auto;
+  overflow: hidden;
+  isolation: isolate;
+  border-radius: clamp(18px, 4vw, 32px);
+  box-shadow: 0 32px 80px rgba(5, 0, 25, 0.55);
+  background: radial-gradient(circle at 50% 0%, rgba(61, 231, 255, 0.12), transparent 65%),
+    rgba(9, 0, 22, 0.85);
 }
 
 .parallax-layer {
@@ -437,16 +351,7 @@ a:focus-visible {
   }
 }
 
-#hero .hero__inner {
-  position: static;
-  top: auto;
-  min-height: auto;
-  display: grid;
-  gap: 3rem;
-  align-items: center;
-  justify-items: center;
-  padding: clamp(6rem, 10vw, 8rem) 0 6rem;
-}
+
 
 .site-footer {
   background: rgba(9, 0, 22, 0.85);
@@ -517,11 +422,11 @@ a:focus-visible {
   }
 
   .hero {
-    padding: 10rem 0 4rem;
+    padding: clamp(5rem, 14vw, 7rem) 0 clamp(3rem, 12vw, 5rem);
   }
 
-  .layer__image {
-    width: min(600px, 120vw);
+  .parallax-stage {
+    width: min(95vmin, 100vw);
   }
 }
 
@@ -530,9 +435,7 @@ a:focus-visible {
     scroll-behavior: auto;
   }
 
-  .parallax,
-  .layer,
-  .layer__image {
+  .parallax-layer {
     animation: none;
     transform: none !important;
   }


### PR DESCRIPTION
## Summary
- restyle the hero stage wrapper to sit beneath the header and frame the animation
- animate hero layers with a scroll-driven timeline that pins the stage and lifts each image in sequence while hero_7 stays anchored
- remove legacy parallax styles that are no longer used after the new animation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6e473ca34832f9a0c23b5a07c754a