### PR TITLE
Implement hero parallax scroll sequence

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,14 +33,14 @@
     <section id="hero" class="hero" aria-label="Starstruck hero">
       <div class="hero__inner">
         <div class="parallax-stage" data-aspect="1" aria-hidden="true">
-          <img id="hero_0" class="parallax-layer" src="hero_0.png" alt="" />
-          <img id="hero_1" class="parallax-layer" src="hero_1.png" alt="" />
-          <img id="hero_2" class="parallax-layer" src="hero_2.png" alt="" />
-          <img id="hero_3" class="parallax-layer" src="hero_3.png" alt="" />
-          <img id="hero_4" class="parallax-layer" src="hero_4.png" alt="" />
-          <img id="hero_5" class="parallax-layer" src="hero_5.png" alt="" />
-          <img id="hero_6" class="parallax-layer" src="hero_6.png" alt="" />
           <img id="hero_7" class="parallax-layer" src="hero_7.png" alt="" />
+          <img id="hero_6" class="parallax-layer" src="hero_6.png" alt="" />
+          <img id="hero_5" class="parallax-layer" src="hero_5.png" alt="" />
+          <img id="hero_4" class="parallax-layer" src="hero_4.png" alt="" />
+          <img id="hero_3" class="parallax-layer" src="hero_3.png" alt="" />
+          <img id="hero_2" class="parallax-layer" src="hero_2.png" alt="" />
+          <img id="hero_1" class="parallax-layer" src="hero_1.png" alt="" />
+          <img id="hero_0" class="parallax-layer" src="hero_0.png" alt="" />
         </div>
         <div class="hero__content container">
           <h1 class="hero__title">Blast Off Into a Funky Musical Universe</h1>

--- a/scripts.js
+++ b/scripts.js
@@ -11,19 +11,24 @@
 
   gsap.registerPlugin(ScrollTrigger);
 
+  const heroSection = document.querySelector('#hero');
   const stage = document.querySelector('#hero .parallax-stage');
-  if (!stage) return;
+  if (!heroSection || !stage) return;
 
   const layers = Array.from(stage.querySelectorAll('.parallax-layer'));
   if (!layers.length) return;
 
   const anchorLayer = stage.querySelector('#hero_7') || layers[layers.length - 1];
-  const movingLayers = layers.filter((layer) => layer !== anchorLayer).reverse();
+  const movingLayers = layers.filter((layer) => layer !== anchorLayer);
 
   if (!movingLayers.length) return;
 
   const baseOffset = 120;
   const offsetStep = 18;
+
+  layers.forEach((layer, index) => {
+    gsap.set(layer, { zIndex: index });
+  });
 
   movingLayers.forEach((layer, index) => {
     const offset = baseOffset + offsetStep * index;
@@ -44,11 +49,11 @@
   const timeline = gsap.timeline({
     defaults: { ease: 'none' },
     scrollTrigger: {
-      trigger: stage,
+      trigger: heroSection,
       start: 'top top',
       end: () => `+=${scrollSpan}%`,
       scrub: true,
-      pin: stage,
+      pin: heroSection,
       anticipatePin: 1,
     },
   });

--- a/styles.css
+++ b/styles.css
@@ -123,6 +123,7 @@ a:focus-visible {
   display: grid;
   gap: clamp(4rem, 8vw, 6rem);
   justify-items: center;
+  align-content: start;
 }
 
 .hero__content {


### PR DESCRIPTION
## Summary
- reorder the hero image stack so the parallax sequence reveals hero_7 through hero_0
- update the GSAP timeline to pin the hero section while bringing each layer into view
- adjust the hero layout so the stage stays anchored to the top during the scroll animation

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d6e77929dc832fa1d584049f1de607