### PR TITLE
Move hero call-to-action below parallax

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,16 +59,16 @@
             <div class="layer__image" role="presentation"></div>
           </div>
         </div>
-        <div class="hero__content container">
-          <h1 class="hero__title">Blast Off Into a Funky Musical Universe</h1>
-          <p class="hero__subtitle">Compose cosmic beats, remix stellar sounds, and explore the galaxy one groove at a time.</p>
-          <a class="cta-button" href="#newsletter">Join the Crew</a>
-        </div>
       </section>
     </section>
 
     <section id="about" class="about section">
       <div class="container narrow">
+        <div class="hero__content">
+          <h1 class="hero__title">Blast Off Into a Funky Musical Universe</h1>
+          <p class="hero__subtitle">Compose cosmic beats, remix stellar sounds, and explore the galaxy one groove at a time.</p>
+          <a class="cta-button" href="#newsletter">Join the Crew</a>
+        </div>
         <p>Explore the Galaxy. Create the Beat. Blast off into a funky musical universe where you are the composer!</p>
         <p>In this vibrant mobile music creation game, you’ll travel from planet to planet, crafting your own unique sound.</p>
         <p>Lay down beats, build looping rhythms, mix smooth chords, and layer melodies to create interstellar tracks that are out of this world.</p>


### PR DESCRIPTION
## Summary
- relocate the hero title, subtitle, and CTA button from the pinned hero section into the following content section
- keep the hero call-to-action centered within the about section so it appears immediately after the parallax experience

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9222cc4f8832fb751b5699cabb5c8