### PR TITLE
Add hero tagline beneath hero logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
       <section id="hero" class="hero" aria-label="Starstruck Galaxy hero section">
         <div class="logo-splash">
           <img src="starstruckgalaxy_logo.png" alt="Starstruck Galaxy" />
+          <p class="logo-splash__tagline">Create. Remix. Explore.</p>
         </div>
         <div class="parallax" aria-hidden="true">
           <div class="layer layer--7" data-speed="0.15" data-reveal="0">

--- a/styles.css
+++ b/styles.css
@@ -129,6 +129,17 @@ a:focus-visible {
   filter: drop-shadow(0 12px 24px rgba(0,0,0,0.45));
 }
 
+.logo-splash__tagline {
+  margin-top: clamp(1rem, 2vw, 1.75rem);
+  font-family: var(--font-display);
+  font-size: clamp(0.75rem, 1.8vw, 1.25rem);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-text);
+  text-align: center;
+  text-shadow: 0 6px 18px rgba(0, 0, 0, 0.45);
+}
+
 .hero {
   position: relative;
   min-height: clamp(720px, 110vh, 960px);


### PR DESCRIPTION
## Summary
- add hero tagline text below the Starstruck Galaxy logo on the landing section
- style the tagline to use the display font and align with the existing splash art

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d924efa330832f8bf267a1976d082d