### PR TITLE
Align hero parallax layers to top

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -186,7 +186,7 @@ a:focus-visible {
 .layer__image {
   width: 100%;
   height: 100%;
-  background-position: center;
+  background-position: center top;
   background-repeat: no-repeat;
   background-size: contain;
 }
@@ -229,7 +229,7 @@ a:focus-visible {
 }
 
 .layer--6 .layer__image {
-  background-image: url('hero_6.png');
+  background-image: url('hero_6_full.png');
 }
 
 .layer--5 .layer__image {


### PR DESCRIPTION
## Summary
- align parallax imagery to the top so taller layers keep the parallax composition
- swap the layer six asset to use the new hero_6_full image

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d92ff212b8832f9d3c434600f00a6c