### PR TITLE
Adjust mobile parallax duration

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
   </header>
 
   <main>
-    <section id="hero-pin" class="hero-pin" style="--pin-height: 400vh;">
+    <section id="hero-pin" class="hero-pin">
       <section id="hero" class="hero" aria-label="Starstruck Galaxy hero section">
         <div class="logo-splash">
           <img src="starstruckgalaxy_logo.png" alt="Starstruck Galaxy" />

--- a/styles.css
+++ b/styles.css
@@ -284,7 +284,7 @@ a:focus-visible {
 
 /* The tall scrollytelling container that creates scroll distance */
 .hero-pin {
-  /* Controls how long the pin lasts. Set via inline --pin-height above. */
+  --pin-height: 400vh; /* default desktop scroll distance */
   height: var(--pin-height, 220vh);
   position: relative;
 }
@@ -540,6 +540,12 @@ a:focus-visible {
 
   .layer__image {
     width: min(600px, 120vw);
+  }
+}
+
+@media (max-width: 600px) {
+  .hero-pin {
+    --pin-height: 280vh; /* shorter scroll distance so hero settles sooner */
   }
 }
 


### PR DESCRIPTION
## Summary
- define the hero pin scroll distance in CSS so it can be tuned per breakpoint
- lower the pin height on narrow viewports to stop the parallax near the bottom of the skull
- remove the inline pin height override so the responsive values apply

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d95cc2ac48832fb7dcc636bfc061d3