### PR TITLE
Remove Record Games logo asset

### DIFF
--- a/index.html
+++ b/index.html
@@ -145,6 +145,15 @@
     <div class="container">
       <p>&copy; <span id="year"></span> Starstruck Galaxy. All rights reserved.</p>
       <a href="privacy.html">Privacy Policy</a>
+      <div class="company-disclaimer" aria-label="Record Games company details">
+        <p class="company-disclaimer__brand">
+          <img src="recordgames_logo.png" alt="Record Games logo" class="company-disclaimer__logo" />
+          <span>Record Games Ltd, &copy; 2025</span>
+        </p>
+        <p>Registered in England and Wales</p>
+        <p>Company Number: 14410136</p>
+        <p>Registered Office: An Grianan, Florida Road, Ferring, West Sussex, BN12 5PE</p>
+      </div>
     </div>
   </footer>
 

--- a/styles.css
+++ b/styles.css
@@ -481,6 +481,30 @@ a:focus-visible {
   gap: 1rem;
 }
 
+.company-disclaimer {
+  flex: 1 1 100%;
+  margin-top: 0.5rem;
+  font-size: 0.75rem;
+  color: rgba(247, 244, 255, 0.6);
+  line-height: 1.4;
+}
+
+.company-disclaimer__brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  color: rgba(247, 244, 255, 0.7);
+}
+
+.company-disclaimer__logo {
+  width: 20px;
+  height: 20px;
+  display: block;
+  filter: brightness(1.1);
+  opacity: 0.8;
+}
+
 .legal {
   background: var(--color-bg);
 }


### PR DESCRIPTION
## Summary
- remove the placeholder Record Games logo image so the asset can be provided separately

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d997ffb5cc832f8e12ae8e7e28f201