### PR TITLE
Adjust footer contrast and strengthen font fallbacks

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -12,7 +12,7 @@
 
 :root {
   --font-body: 'BM Hanna Pro', 'Noto Sans', 'Helvetica Neue', Arial, sans-serif;
-  --font-display: 'Pixel Punk', 'BM Hanna Pro', cursive;
+  --font-display: 'Pixel Punk', 'BM Hanna Pro', 'Noto Sans', 'Helvetica Neue', Arial, sans-serif;
   --color-bg: #0d0221;
   --color-bg-alt: #13062b;
   --color-surface: rgba(19, 6, 43, 0.8);
@@ -485,7 +485,7 @@ a:focus-visible {
   flex: 1 1 100%;
   margin-top: 0.5rem;
   font-size: 0.75rem;
-  color: rgba(247, 244, 255, 0.6);
+  color: rgba(247, 244, 255, 0.45);
   line-height: 1.4;
 }
 
@@ -494,7 +494,7 @@ a:focus-visible {
   align-items: center;
   gap: 0.5rem;
   font-weight: 600;
-  color: rgba(247, 244, 255, 0.7);
+  color: rgba(247, 244, 255, 0.55);
 }
 
 .company-disclaimer__logo {


### PR DESCRIPTION
## Summary
- soften the footer company info colors so the text is readable but less attention-grabbing
- extend the display font stack to include basic system fallbacks for missing glyphs like the copyright symbol

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d999ed3a74832f81734831738b060b