### PR TITLE
Move newsletter intro text into signup form

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,8 +82,6 @@
 
     <section id="newsletter" class="newsletter section" aria-label="Newsletter sign-up">
       <div class="container narrow">
-        <h2>Stay in the Loop</h2>
-        <p>Be the first to know about playtests, soundtrack drops, and development updates.</p>
         <div class="newsletter__embed" role="region" aria-live="polite">
 
           <!-- MailerLite embed (minimal) -->
@@ -95,8 +93,11 @@
                       method="post"
                       target="_blank"
                       novalidate>
-                  
                   <div class="ml-form-formContent">
+                    <div class="newsletter__heading">
+                      <h2>Stay in the Loop</h2>
+                      <p>Be the first to know about playtests, soundtrack drops, and development updates.</p>
+                    </div>
                     <div class="ml-form-fieldRow ml-last-item">
                       <div class="ml-field-group ml-field-email ml-validate-email ml-validate-required">
                         <label for="newsletter-email" class="sr-only">Email</label>


### PR DESCRIPTION
## Summary
- move the newsletter heading and description into the embedded signup form so the text appears directly above the email input

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd451a1ce4832f99fe73105bfd8ee1